### PR TITLE
7 expand baud rate support and fix macOS CI workflow

### DIFF
--- a/.github/workflows/macos_package.yml
+++ b/.github/workflows/macos_package.yml
@@ -17,7 +17,7 @@ jobs:
             ARCH_SUFFIX: MacOS-arm64 # Suffix for file names, if needed
 
           # Configuration for Intel architecture
-          - os: macos-13 # macos-13 is a good option for x86_64, macos-latest might be ARM
+          - os: macos-15-intel # macos-15-intel is a good option for x86_64, macos-latest might be ARM
             TARGET: x86_64-apple-darwin
             ARCH_SUFFIX: MacOS-x64 # Suffix for file names, if needed
     env:

--- a/src/serial_impl/portsettings.rs
+++ b/src/serial_impl/portsettings.rs
@@ -5,18 +5,86 @@ pub struct BaudRate {
     pub numeric_repr: u32,
 }
 
-pub const BAUD_RATES: [BaudRate; 3] = [
+pub const BAUD_RATES: [BaudRate; 20] = [
+    BaudRate {
+        string_repr: "110",
+        numeric_repr: 110,
+    },
+    BaudRate {
+        string_repr: "300",
+        numeric_repr: 300,
+    },
+    BaudRate {
+        string_repr: "600",
+        numeric_repr: 600,
+    },
+    BaudRate {
+        string_repr: "1200",
+        numeric_repr: 1200,
+    },
+    BaudRate {
+        string_repr: "2400",
+        numeric_repr: 2400,
+    },
+    BaudRate {
+        string_repr: "4800",
+        numeric_repr: 4800,
+    },
     BaudRate {
         string_repr: "9600",
         numeric_repr: 9600,
+    },
+    BaudRate {
+        string_repr: "14400",
+        numeric_repr: 14400,
+    },
+    BaudRate {
+        string_repr: "19200",
+        numeric_repr: 19200,
     },
     BaudRate {
         string_repr: "38400",
         numeric_repr: 38400,
     },
     BaudRate {
+        string_repr: "57600",
+        numeric_repr: 57600,
+    },
+    BaudRate {
         string_repr: "115200",
         numeric_repr: 115200,
+    },
+    BaudRate {
+        string_repr: "128000",
+        numeric_repr: 128000,
+    },
+    BaudRate {
+        string_repr: "230400",
+        numeric_repr: 230400,
+    },
+    BaudRate {
+        string_repr: "256000",
+        numeric_repr: 256000,
+    },
+    BaudRate {
+        string_repr: "460800",
+        numeric_repr: 460800,
+    },
+    BaudRate {
+        string_repr: "921600",
+        numeric_repr: 921600,
+    },
+    BaudRate {
+        string_repr: "1000000",
+        numeric_repr: 1_000_000,
+    },
+    BaudRate {
+        string_repr: "2000000",
+        numeric_repr: 2_000_000,
+    },
+    BaudRate {
+        string_repr: "3000000",
+        numeric_repr: 3_000_000,
     },
 ];
 pub struct PortSettings {
@@ -31,7 +99,7 @@ impl Default for PortSettings {
     fn default() -> Self {
         PortSettings {
             port_name: String::new(),
-            baudrate: BAUD_RATES[2].numeric_repr, // Por ejemplo, 115200
+            baudrate: BAUD_RATES[11].numeric_repr, // 115200
             flowcontrol: FlowControl::None,
             parity: Parity::None,
             stop_bits: StopBits::One,


### PR DESCRIPTION
This PR addresses two main areas: expanding the supported baud rates for the serial monitor to improve hardware compatibility and fixing a broken macOS build in GitHub Actions.

Changes
1. Expanded Baud Rate Support
Increased Options: Updated the BAUD_RATES array from 3 to 20 supported rates.

Range: Now includes standard low speeds (110, 300, 600) and high-speed rates (up to 3,000,000) common in modern development (ESP32, high-speed sensors, etc.).

Default Settings: Updated the default PortSettings index to 11 to ensure the default remains 115200 despite the array expansion.

2. CI/CD Fix (GitHub Actions)
macOS Runner Update: Migrated the Intel build runner from macos-13 to macos-15-intel.

Reason: The previous configuration was causing failures in the packaging workflow. Using the specific -intel runner ensures stable builds for the x86_64-apple-darwin target.